### PR TITLE
Fixed offsets and sigs + how-to

### DIFF
--- a/hack.cpp
+++ b/hack.cpp
@@ -97,7 +97,7 @@ void hack::Glow(double colors[12], remote::Handle* csgo, remote::MapModuleMemory
 						unsigned int entityId = 0;
 						unsigned int attack = 0x5;
 						unsigned int release = 0x4;
-						csgo->Read((void*) (localPlayer+0xB398), &crossHairId, sizeof(int));
+						csgo->Read((void*) (localPlayer+0xBBD8), &crossHairId, sizeof(int));
 						csgo->Read((void*) (g_glow[i].m_pEntity + 0x94), &entityId, sizeof(int));
 
 						unsigned int iAlt1Status = 0 ;

--- a/main.cpp
+++ b/main.cpp
@@ -156,22 +156,25 @@ int main() {
 	Logger::address ("engine_client.so:\t", pEngine);
 
 	void* foundGlowPointerCall = client.find(csgo,
-		"\xE8\x00\x00\x00\x00\x48\x8b\x10\x49\xc1\xe5\x06\x46", // 2016-10-08
-		"x????xxxxxxxx");
+		"\xE8\x00\x00\x00\x00\x48\x8b\x3d\x00\x00\x00\x00\xBE\x01\x00\x00\x00\xC7", // 2016-10-08
+		"x????xxx????xxxxxx");
 
-	unsigned long call = csgo.GetCallAddress(foundGlowPointerCall);
+	unsigned long glowFunctionCall = csgo.GetCallAddress(foundGlowPointerCall);
+	Logger::address ("Glow function call:\t", glowFunctionCall);
 
-
-	Logger::address ("Glow function:\t", call);
-
-	csgo.m_addressOfGlowPointer = csgo.GetCallAddress((void*)(call+0xF));
-	Logger::address ("Glow array pointer:\t", csgo.m_addressOfGlowPointer);
+	int addressOfGlowPointerOffset;
+	csgo.Read((void*) (glowFunctionCall + 0x10), &addressOfGlowPointerOffset, sizeof(int));
+	Logger::address ("Glow relative ptr:\t", addressOfGlowPointerOffset);
+	
+	csgo.m_addressOfGlowPointer = glowFunctionCall + 0x10 + addressOfGlowPointerOffset + 0x4;
+	Logger::address ("GlowObjMan pointer:\t", csgo.m_addressOfGlowPointer);
 
 	unsigned long foundLocalPlayerLea = (long)client.find(csgo,
 		"\x48\x89\xe5\x74\x0e\x48\x8d\x05\x00\x00\x00\x00", //27/06/16
 		"xxxxxxxx????");
 
 	csgo.m_addressOfLocalPlayer = csgo.GetCallAddress((void*)(foundLocalPlayerLea+0x7));
+	Logger::address ("LocalPlayer address:\t", csgo.m_addressOfLocalPlayer);
 
 	unsigned long foundAttackMov = (long)client.find(csgo,
 		"\x44\x89\xe8\x83\xe0\x01\xf7\xd8\x83\xe8\x03\x45\x84\xe4\x74\x00\x21\xd0", //10/07/16
@@ -183,7 +186,7 @@ int main() {
 		"xxxxxxxxxxxxxxxx?xx");
 
 	csgo.m_addressOfAlt1 = csgo.GetCallAddress((void*)(foundAlt1Mov+20));
-	Logger::address ("LocalPlayer address:\t", csgo.m_addressOfLocalPlayer);
+	Logger::address ("alt1 address:\t\t", csgo.m_addressOfAlt1);	
 
 	/*
 		0x7f114cc6f414:	 and	eax,edx


### PR DESCRIPTION
Seems like crosshair ID changes often. Glow signature doesn't change at all.
To find it, look up `C_CSPlayer::GetIDTarget(void)` in Mac binaries. The *mov* right above the first *test* instruction contains our offset - 0xB398.

We can use `CountdownTimer::Now(void)` to find it on Linux. The function below contains "m_timestamp" string, let's use this as starting point. Look up its first reference on Linux. Above that whole subroutine is another one with "IntervalTimer" and above that is the `CountdownTimer::Now(void)` function we need (looks pretty similiar to the one in Mac binaries).

Now find all references to that function (Ctrl+X with the cursor on sub_xxxxx). We should see ~60 lines. On macOS, we can see that the function we're interested in - `C_CSPlayer::GetIDTarget(void)` - is on lines 27 and 28, 0x28 bytes apart. In Linux binaries, we can see the same pattern. The function is, however, on lines 25 and 26 and 0x37 bytes apart. Close enough. Doubleclick the line 25.

The function we just found is `C_CSPlayer::GetIDTarget(void)`. As I said, the first *mov* above the first *test* instruction contains our offset.

I know, that this is a pretty ghetto way of finding it, but that's how I did it.